### PR TITLE
Ensure every qubit is initialized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,12 @@ test: lint unit-tests
 
 #### Build
 
-build:
+build: install
 	rm -rf $(BUILD_DIR)
 	. $(ACTIVATE) && python -m build -o $(BUILD_DIR)
 
 test-publish: build
-	twine upload -r testpypi dist/*
+	. $(ACTIVATE) && python -m twine upload -r testpypi dist/*
 
 publish: build
-	twine upload dist/*
+	. $(ACTIVATE) && python -m twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qiskit_alice_bob_provider"
 authors = [
     {name = "Alice & Bob Software Team"},
 ]
-version = "0.1.1"
+version = "0.1.2"
 description = "Provider for running Qiskit circuits on Alice & Bob QPUs and simulators"
 readme = "README.md"
 license = {text = "Apache 2.0"}

--- a/qiskit_alice_bob_provider/backend.py
+++ b/qiskit_alice_bob_provider/backend.py
@@ -18,11 +18,12 @@ from typing import Any, Dict
 
 from qiskit import QuantumCircuit
 from qiskit.providers import BackendV2, Options
-from qiskit.transpiler import Target
+from qiskit.transpiler import PassManager, Target
 from qiskit_qir import to_qir_module
 
 from .api import jobs
 from .api.client import ApiClient
+from .ensure_preparation_pass import EnsurePreparationPass
 from .job import AliceBobJob
 from .qir_to_qiskit import ab_target_to_qiskit_target
 from .utils import camel_to_snake_case, snake_to_camel_case
@@ -87,6 +88,7 @@ class AliceBobBackend(BackendV2):
             options.update_options(**{key: value})
         input_params = _ab_input_params_from_options(options)
         job = jobs.create_job(self._api_client, self.name, input_params)
+        run_input = PassManager([EnsurePreparationPass()]).run(run_input)
         jobs.upload_input(
             self._api_client, job['id'], _qiskit_to_qir(run_input)
         )

--- a/qiskit_alice_bob_provider/ensure_preparation_pass.py
+++ b/qiskit_alice_bob_provider/ensure_preparation_pass.py
@@ -1,0 +1,72 @@
+##############################################################################
+# Copyright 2023 Alice & Bob
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+
+from qiskit.circuit import Qubit, Reset
+from qiskit.dagcircuit import DAGCircuit, DAGInNode, DAGOpNode
+from qiskit.transpiler import TransformationPass
+
+
+class EnsurePreparationPass(TransformationPass):
+    """
+    A transpilation pass that ensures there is a state preparation at the
+    beginning of the circuit.
+
+    If there isn't, a Reset is added (i.e. prepare the zero state in the
+    Z basis).
+
+    The reason for this pass is that Qiskit runs the `RemoveResetInZeroState`
+    pass as part of the default transpilation passes, in most cases (precisely
+    for optimization_level >=1, the default being 1).
+
+    The community seems to agree that this behavior is a bad decision and
+    should be removed. https://github.com/Qiskit/qiskit-terra/issues/6943
+    The rationale for this behavior was that IBM backends always reset the
+    qubits to zero between shots. This behavior cannot be assumed to be true
+    for all backends, including Alice & Bob's.
+    Once this issue is resolved, this transpilation pass should be removed from
+    the Alice & Bob provider.
+
+    This transpilation pass cannot be added to the transpilation stage plugin
+    of the Alice & Bob provider, because the `RemoveResetInZeroState` runs
+    in the optimization stage, which happens after the transpilation stage.
+
+    For this reason, this pass is run manually right before the compilation
+    from Qiskit to QIR.
+    """
+
+    def run(self, dag: DAGCircuit) -> DAGCircuit:
+        preparations = {'reset', 'initialize', 'state_preparation'}
+        for node in dag.topological_nodes():
+            if not isinstance(node, DAGInNode):
+                continue
+            if not isinstance(node.wire, Qubit):
+                continue
+            for successor in dag.successors(node):
+                if not isinstance(successor, DAGOpNode):
+                    continue
+                if successor.name in preparations:
+                    continue
+                new_dag = DAGCircuit()
+                new_dag.add_qubits(successor.qargs)
+                new_dag.add_clbits(successor.cargs)
+                new_dag.apply_operation_back(Reset(), qargs=(node.wire,))
+                new_dag.apply_operation_back(
+                    successor.op,
+                    qargs=successor.qargs,
+                    cargs=successor.cargs,
+                )
+                dag.substitute_node_with_dag(successor, new_dag)
+        return dag

--- a/tests/test_ensure_preparation_pass.py
+++ b/tests/test_ensure_preparation_pass.py
@@ -1,0 +1,38 @@
+##############################################################################
+# Copyright 2023 Alice & Bob
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+
+from qiskit import QuantumCircuit
+from qiskit.transpiler import PassManager
+
+from qiskit_alice_bob_provider.ensure_preparation_pass import (
+    EnsurePreparationPass,
+)
+
+_pm = PassManager([EnsurePreparationPass()])
+
+
+def test_missing_prep() -> None:
+    c = QuantumCircuit(3, 1)
+    c.x(0)
+    c.reset(1)
+    c.y(1)
+    c.initialize('+', 2)
+    c.cnot(1, 2)
+    c.measure(2, 0)
+    new_c = _pm.run(c)
+    expected = c.count_ops()
+    expected['reset'] += 1
+    assert dict(new_c.count_ops()) == dict(expected)


### PR DESCRIPTION
From the docstring of `EnsurePreparationPass`:

A transpilation pass that ensures there is a state preparation at the
beginning of the circuit.

If there isn't, a Reset is added (i.e. prepare the zero state in the Z basis).

The reason for this pass is that Qiskit runs the `RemoveResetInZeroState`
pass as part of the default transpilation passes, in most cases (precisely
for optimization_level >=1, the default being 1).

The community seems to agree that this behavior is a bad decision and
should be removed. https://github.com/Qiskit/qiskit-terra/issues/6943
The rationale for this behavior was that IBM backends always reset the
qubits to zero between shots. This behavior cannot be assumed to be true
for all backends, including Alice & Bob's.
Once this issue is resolved, this transpilation pass should be removed from
the Alice & Bob provider.

This transpilation pass cannot be added to the transpilation stage plugin
of the Alice & Bob provider, because the `RemoveResetInZeroState` runs
in the optimization stage, which happens after the transpilation stage.

For this reason, this pass is run manually right before the compilation
from Qiskit to QIR.