### PR TITLE
Fix rounding inequalities and allow Makefile to choose between python and python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
 VENV=venv
-PYTHON=python
+
 MODULES=qiskit_alice_bob_provider tests
 BUILD_DIR=dist
 BASE_URL=
 API_KEY=
 ifeq ($(OS),Windows_NT)
     ACTIVATE=$(VENV)/Scripts/activate
+    PYTHON3_PATH=$(cmd which python3 2> nul)
 else
     ACTIVATE=$(VENV)/bin/activate
+    PYTHON3_PATH=$(shell which python3 2> /dev/null)
+endif
+
+ifeq ($(PYTHON3_PATH),)
+    PYTHON=python
+else
+    PYTHON=python3
 endif
 
 #### Virtual environment

--- a/qiskit_alice_bob_provider/translation_plugin.py
+++ b/qiskit_alice_bob_provider/translation_plugin.py
@@ -113,13 +113,13 @@ def _substitute_single_qubit_initialize(
     elif len(state) == 2 and isinstance(state[0], complex):
         global_phase = np.angle(state[0])
         state_ph = np.array(state) * np.exp(-1j * global_phase)
-        if np.array_equal(state_ph, np.array([1, 0])):
+        if np.allclose(state_ph, np.array([1, 0])):
             return Reset()
-        elif np.array_equal(state_ph, np.array([0, 1])):
+        elif np.allclose(state_ph, np.array([0, 1])):
             return Initialize([0, 1])
-        elif np.array_equal(state_ph, np.array([1, 1]) / np.sqrt(2)):
+        elif np.allclose(state_ph, np.array([1, 1]) / np.sqrt(2)):
             return None
-        elif np.array_equal(state_ph, np.array([1, -1]) / np.sqrt(2)):
+        elif np.allclose(state_ph, np.array([1, -1]) / np.sqrt(2)):
             return None
     raise AliceBobTranspilationException(
         f'The Initialize state preparation with desired state {state} is '


### PR DESCRIPTION
Some machines including mine were having float rounding issues when translating some gates (the state phase was equal to 1 + 1e-18j which was not equal to 1)

This PR replaces the array_equal function by allclose, using the default thresholds to ensure this comparison will work even with float issues. It also improves the Makefile to detect if `python3` is an available command on the users machine to use it instead.

Safe to revert.

