### PR TITLE
Update Qiskit provider to use the new backend names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Where `MY_API_KEY` is your API key to the Alice & Bob API.
 
 ```python
 print(ab.backends())
-backend = ab.get_backend('SINGLE_CAT')
+backend = ab.get_backend('EMU:1Q:LESCANNE_2020')
 ```
 
 The backend can then be used like a regular Qiskit backend:
@@ -56,16 +56,16 @@ from qiskit import QuantumCircuit, execute, transpile
 
 provider = AliceBobLocalProvider()
 print(provider.backends())
-# PHYSICAL_CATS_6, PHYSICAL_CATS_40, LESCANNE_2020
+# EMU:6Q:PHYSICAL_CATS, EMU:40Q:PHYSICAL_CATS, EMU:1Q:LESCANNE_2020
 ```
 
-The `PHYSICAL_CATS` backends are theoretical models of quantum processors made
+The `EMU:nQ:PHYSICAL_CATS` backends are theoretical models of quantum processors made
 up of physical cat qubits.
 They can be used to study the properties of error correction codes implemented
 with physical cat qubits, for different hardware performance levels
 (see the parameters of class `PhysicalCatProcessor`).
 
-The `LESCANNE_2020` backend is an interpolated model simulating the processor
+The `EMU:1Q:LESCANNE_2020` backend is an interpolated model simulating the processor
 used in the [seminal paper](https://arxiv.org/pdf/1907.11729.pdf) by Raphaël
 Lescanne in 2020.
 This interpolated model is configured to act as a digital twin of the cat qubit
@@ -73,7 +73,7 @@ used in this paper.
 It does not represent the current performance of Alice & Bob's cat qubits.
 
 The example below schedules and simulates a Bell state preparation circuit on
-a `PHYSICAL_CATS_6` processor, for different values of parameters `alpha` and
+a `EMU:6Q:PHYSICAL_CATS` processor, for different values of parameters `alpha` and
 `kappa_2`.
 
 ```python
@@ -90,7 +90,7 @@ circ.measure(1, 1)
 
 # Default 6-qubit QPU with the ratio of memory dissipation rates set to
 # k1/k2=1e-5 and cat amplitude alpha set to 4.
-backend = provider.get_backend('PHYSICAL_CATS_6')
+backend = provider.get_backend('EMU:6Q:PHYSICAL_CATS')
 
 print(transpile(circ, backend).draw())
 # *Displays a timed and scheduled circuit*
@@ -99,7 +99,7 @@ print(execute(circ, backend, shots=100000).result().get_counts())
 # {'11': 49823, '00': 50177}
 
 # Changing the cat amplitude from 4 (default) to 2 and k1/k2 to 1e-2.
-backend = provider.get_backend('PHYSICAL_CATS_6', alpha=2, kappa_2=1e4)
+backend = provider.get_backend('EMU:6Q:PHYSICAL_CATS', alpha=2, kappa_2=1e4)
 print(execute(circ, backend, shots=100000).result().get_counts())
 # {'01': 557, '11': 49422, '10': 596, '00': 49425}
 ```

--- a/qiskit_alice_bob_provider/local/provider.py
+++ b/qiskit_alice_bob_provider/local/provider.py
@@ -41,22 +41,22 @@ class AliceBobLocalProvider(ProviderV1):
         self._backend_builders: Dict[
             str, Callable[..., ProcessorSimulator]
         ] = {}
-        self._backend_builders['PHYSICAL_CATS_6'] = partial(
+        self._backend_builders['EMU:6Q:PHYSICAL_CATS'] = partial(
             self.build_physical_backend,
             n_qubits=6,
             coupling_map=circular_map(6),
-            name='PHYSICAL_CATS_6',
+            name='EMU:6Q:PHYSICAL_CATS',
         )
-        self._backend_builders['PHYSICAL_CATS_40'] = partial(
+        self._backend_builders['EMU:40Q:PHYSICAL_CATS'] = partial(
             self.build_physical_backend,
             n_qubits=40,
             coupling_map=rectangular_map(5, 8),
-            name='PHYSICAL_CATS_40',
+            name='EMU:40Q:PHYSICAL_CATS',
         )
-        self._backend_builders['LESCANNE_2020'] = partial(
+        self._backend_builders['EMU:1Q:LESCANNE_2020'] = partial(
             self.build_from_serialized,
             file_path=str(_PARENT_DIR / 'resources' / 'lescanne_2020.json'),
-            name='LESCANNE_2020',
+            name='EMU:1Q:LESCANNE_2020',
         )
         self._backends = [func() for func in self._backend_builders.values()]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def api_key(request):
 @pytest.fixture
 def single_cat_target() -> dict:
     return {
-        'name': 'SINGLE_CAT_SIMULATOR',
+        'name': 'EMU:1Q:LESCANNE_2020',
         'numQubits': 1,
         'instructions': [
             {'signature': '__quantum__qis__read_result__body:i1 (%Result*)'},
@@ -214,7 +214,7 @@ def _job_response(job_id: str, events: List[Dict], errors: List[Dict]) -> dict:
     return {
         'inputDataFormat': 'HUMAN_QIR',
         'outputDataFormat': 'HISTOGRAM',
-        'target': 'SINGLE_CAT_SIMULATOR',
+        'target': 'EMU:1Q:LESCANNE_2020',
         'inputParams': {'nbShots': 100, 'averageNbPhotons': 4.0},
         'id': job_id,
         'userName': 'john',

--- a/tests/local/test_provider.py
+++ b/tests/local/test_provider.py
@@ -4,7 +4,9 @@ from qiskit_alice_bob_provider.local.provider import AliceBobLocalProvider
 def test_get_backends() -> None:
     ab = AliceBobLocalProvider()
     ab.backends()
-    assert ab.get_backend('PHYSICAL_CATS_6').name == 'PHYSICAL_CATS_6'
-    backends = ab.backends('PHYSICAL_CATS_6')
+    assert (
+        ab.get_backend('EMU:6Q:PHYSICAL_CATS').name == 'EMU:6Q:PHYSICAL_CATS'
+    )
+    backends = ab.backends('EMU:6Q:PHYSICAL_CATS')
     assert len(backends) == 1
-    assert ab.get_backend('PHYSICAL_CATS_6').name == backends[0].name
+    assert ab.get_backend('EMU:6Q:PHYSICAL_CATS').name == backends[0].name

--- a/tests/test_against_real_server.py
+++ b/tests/test_against_real_server.py
@@ -34,7 +34,7 @@ def test_happy_path(base_url: str, api_key: str) -> None:
         api_key=api_key,
         url=base_url,
     )
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     res = job.result()
     res.get_counts()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -34,7 +34,7 @@ from qiskit_alice_bob_provider.provider import AliceBobProvider
 def test_options_validation(mocked_targets) -> None:
     c = QuantumCircuit(1, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     with pytest.raises(ValueError):
         execute(c, backend, average_nb_photons=40)
     with pytest.raises(ValueError):
@@ -50,7 +50,7 @@ def test_options_validation(mocked_targets) -> None:
 def test_too_many_qubits_clients_side(mocked_targets) -> None:
     c = QuantumCircuit(3, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     with pytest.raises(TranspilerError):
         execute(c, backend)
 
@@ -61,7 +61,7 @@ def test_counts_ordering(successful_job: Mocker) -> None:
     c.measure_x(0, 0)
     c.measure(0, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     counts = job.result(wait=0).get_counts()
     expected = {'11': 12, '10': 474, '01': 6, '00': 508}
@@ -73,7 +73,7 @@ def test_counts_ordering(successful_job: Mocker) -> None:
 def test_failed_transpilation(failed_transpilation_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     res: Result = job.result(wait=0)
     assert res.results[0].data.input_qir is not None
@@ -88,7 +88,7 @@ def test_failed_transpilation(failed_transpilation_job: Mocker) -> None:
 def test_failed_execution(failed_execution_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     res: Result = job.result(wait=0)
     assert res.results[0].data.input_qir is not None
@@ -100,7 +100,7 @@ def test_failed_execution(failed_execution_job: Mocker) -> None:
 def test_cancel_job(cancellable_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     job.cancel()
     res: Result = job.result(wait=0)
@@ -113,7 +113,7 @@ def test_cancel_job(cancellable_job: Mocker) -> None:
 def test_failed_server_side_validation(failed_validation_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
     provider = AliceBobProvider(api_key='foo')
-    backend = provider.get_backend('SINGLE_CAT_SIMULATOR')
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     with pytest.raises(AliceBobApiException):
         execute(c, backend)
 


### PR DESCRIPTION
We recently agreed on a naming convention for our backends and implemented them already on the server side. As the provider also needs to use the newest backend names, this PR will do this change for the local backends, the README and the tests.

The changed name are:
- For remote:
SINGLE_CAT_SIMULATOR -> EMU:1Q:LESCANNE_2020

- For local:
LESCANNE_2020 -> EMU:1Q:LESCANNE_2020
PHYSICAL_CATS_6 -> EMU:6Q:PHYSICAL_CATS
PHYSICAL_CATS_40 -> EMU:40Q:PHYSICAL_CATS

We tested these changes, including by running the integration test. I also tried the new provided codes of the README and ensure they were working properly.

Safe to revert
