### PR TITLE
Include Remote in the class names of provider, backends and jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ will always install the  latest (and well-tested) version.
 
 To obtain an API key, please [contact Alice & Bob](https://alice-bob.com/contact/).
 
-You can initialize the Alice & Bob provider using your API key locally with:
+You can initialize the Alice & Bob remote provider using your API key
+locally with:
 
 ```python
-from qiskit_alice_bob_provider import AliceBobProvider
-ab = AliceBobProvider('MY_API_KEY')
+from qiskit_alice_bob_provider import AliceBobRemoteProvider
+ab = AliceBobRemoteProvider('MY_API_KEY')
 ```
 
 Where `MY_API_KEY` is your API key to the Alice & Bob API.

--- a/qiskit_alice_bob_provider/__init__.py
+++ b/qiskit_alice_bob_provider/__init__.py
@@ -17,4 +17,4 @@
 # flake8: noqa: F401
 
 from .local import AliceBobLocalProvider
-from .provider import AliceBobProvider
+from .provider import AliceBobRemoteProvider

--- a/qiskit_alice_bob_provider/backend.py
+++ b/qiskit_alice_bob_provider/backend.py
@@ -29,9 +29,8 @@ from .qir_to_qiskit import ab_target_to_qiskit_target
 from .utils import camel_to_snake_case, snake_to_camel_case
 
 
-class AliceBobBackend(BackendV2):
-    """Class representing the single cat simulator target accessible via the
-    Alice & Bob API"""
+class AliceBobRemoteBackend(BackendV2):
+    """Class representing the targets accessible via the Alice & Bob API."""
 
     def __init__(self, api_client: ApiClient, target_description: Dict):
         """This class should be instantiated by the AliceBobRemoteProvider.
@@ -48,7 +47,7 @@ class AliceBobBackend(BackendV2):
         self._options = _options_from_ab_target(target_description)
 
     def __repr__(self) -> str:
-        return f'<AliceBobBackend(name={self.name})>'
+        return f'<AliceBobRemoteBackend(name={self.name})>'
 
     @property
     def target(self) -> Target:
@@ -74,7 +73,8 @@ class AliceBobBackend(BackendV2):
         Args:
             run_input (QuantumCircuit): a Qiskit circuit
             **kwargs: additional arguments are interpreted as backend options.
-                List all options by calling :func:`AliceBobBackend.options`
+                List all options by calling
+                :func:`AliceBobRemoteBackend.options`
 
         Returns:
             AliceBobJob: A Qiskit job that is a reference to the job created in

--- a/qiskit_alice_bob_provider/backend.py
+++ b/qiskit_alice_bob_provider/backend.py
@@ -24,7 +24,7 @@ from qiskit_qir import to_qir_module
 from .api import jobs
 from .api.client import ApiClient
 from .ensure_preparation_pass import EnsurePreparationPass
-from .job import AliceBobJob
+from .job import AliceBobRemoteJob
 from .qir_to_qiskit import ab_target_to_qiskit_target
 from .utils import camel_to_snake_case, snake_to_camel_case
 
@@ -66,7 +66,7 @@ class AliceBobRemoteBackend(BackendV2):
         in translation_plugin.StatePreparationPlugin"""
         return 'state_preparation'
 
-    def run(self, run_input: QuantumCircuit, **kwargs) -> AliceBobJob:
+    def run(self, run_input: QuantumCircuit, **kwargs) -> AliceBobRemoteJob:
         """Run the quantum circuit on the Alice & Bob backend by calling the
         Alice & Bob API.
 
@@ -77,9 +77,10 @@ class AliceBobRemoteBackend(BackendV2):
                 :func:`AliceBobRemoteBackend.options`
 
         Returns:
-            AliceBobJob: A Qiskit job that is a reference to the job created in
-                the Alice & Bob API. The job is already started. Wait for the
-                results by calling :func:`AliceBobJob.result`.
+            AliceBobRemoteJob: A Qiskit job that is a reference to the job
+                created in the Alice & Bob API. The job is already started.
+                Wait for the results by calling
+                :func:`AliceBobRemoteJob.result`.
         """
         options: Options = self.options
         for key, value in kwargs.items():
@@ -92,7 +93,7 @@ class AliceBobRemoteBackend(BackendV2):
         jobs.upload_input(
             self._api_client, job['id'], _qiskit_to_qir(run_input)
         )
-        return AliceBobJob(
+        return AliceBobRemoteJob(
             backend=self,
             api_client=self._api_client,
             job_id=job['id'],

--- a/qiskit_alice_bob_provider/backend.py
+++ b/qiskit_alice_bob_provider/backend.py
@@ -34,7 +34,7 @@ class AliceBobBackend(BackendV2):
     Alice & Bob API"""
 
     def __init__(self, api_client: ApiClient, target_description: Dict):
-        """This class should be instantiated by the AliceBobProvider.
+        """This class should be instantiated by the AliceBobRemoteProvider.
 
         Args:
             api_client (ApiClient): a client for the Alice & Bob API.

--- a/qiskit_alice_bob_provider/job.py
+++ b/qiskit_alice_bob_provider/job.py
@@ -57,7 +57,7 @@ class AliceBobJob(JobV1):
         circuit: QuantumCircuit,
     ):
         """A job should not be instantiated manually but created by calling
-        :func:`AliceBobBackend.run` or :func:`qiskit.execute`.
+        :func:`AliceBobRemoteBackend.run` or :func:`qiskit.execute`.
 
         Args:
             backend (BackendV2): a reference to the backend that created this

--- a/qiskit_alice_bob_provider/job.py
+++ b/qiskit_alice_bob_provider/job.py
@@ -46,7 +46,7 @@ class _DownloadedFile:
     content: Optional[str]
 
 
-class AliceBobJob(JobV1):
+class AliceBobRemoteJob(JobV1):
     """A Qiskit job referencing a job executed in the Alice & Bob API"""
 
     def __init__(

--- a/qiskit_alice_bob_provider/provider.py
+++ b/qiskit_alice_bob_provider/provider.py
@@ -21,7 +21,7 @@ from qiskit.providers.providerutils import filter_backends
 
 from .api.client import ApiClient
 from .api.targets import list_targets
-from .backend import AliceBobBackend
+from .backend import AliceBobRemoteBackend
 
 
 class AliceBobRemoteProvider(ProviderV1):
@@ -50,7 +50,7 @@ class AliceBobRemoteProvider(ProviderV1):
         )
         self._backends = []
         for ab_target in list_targets(client):
-            self._backends.append(AliceBobBackend(client, ab_target))
+            self._backends.append(AliceBobRemoteBackend(client, ab_target))
 
     def backends(
         self, name: Optional[str] = None, **kwargs

--- a/qiskit_alice_bob_provider/provider.py
+++ b/qiskit_alice_bob_provider/provider.py
@@ -24,8 +24,10 @@ from .api.targets import list_targets
 from .backend import AliceBobBackend
 
 
-class AliceBobProvider(ProviderV1):
-    """Class listing and providing access to all Alice & Bob backends."""
+class AliceBobRemoteProvider(ProviderV1):
+    """
+    Class listing and providing access to all Alice & Bob remote backends.
+    """
 
     def __init__(
         self,

--- a/tests/test_against_real_server.py
+++ b/tests/test_against_real_server.py
@@ -17,7 +17,7 @@
 import pytest
 from qiskit import QuantumCircuit, execute
 
-from qiskit_alice_bob_provider import AliceBobProvider
+from qiskit_alice_bob_provider import AliceBobRemoteProvider
 
 realserver = pytest.mark.skipif(
     "not config.getoption('api_key') and not config.getoption('base_url')"
@@ -30,7 +30,7 @@ def test_happy_path(base_url: str, api_key: str) -> None:
     c.initialize('+', 0)
     c.measure_x(0, 0)
     c.measure(0, 1)
-    provider = AliceBobProvider(
+    provider = AliceBobRemoteProvider(
         api_key=api_key,
         url=base_url,
     )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -28,12 +28,12 @@ from qiskit_alice_bob_provider.backend import (
     _ab_input_params_from_options,
     _qiskit_to_qir,
 )
-from qiskit_alice_bob_provider.provider import AliceBobProvider
+from qiskit_alice_bob_provider.provider import AliceBobRemoteProvider
 
 
 def test_options_validation(mocked_targets) -> None:
     c = QuantumCircuit(1, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     with pytest.raises(ValueError):
         execute(c, backend, average_nb_photons=40)
@@ -49,7 +49,7 @@ def test_options_validation(mocked_targets) -> None:
 
 def test_too_many_qubits_clients_side(mocked_targets) -> None:
     c = QuantumCircuit(3, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     with pytest.raises(TranspilerError):
         execute(c, backend)
@@ -60,7 +60,7 @@ def test_counts_ordering(successful_job: Mocker) -> None:
     c.initialize('+', 0)
     c.measure_x(0, 0)
     c.measure(0, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     counts = job.result(wait=0).get_counts()
@@ -72,7 +72,7 @@ def test_counts_ordering(successful_job: Mocker) -> None:
 
 def test_failed_transpilation(failed_transpilation_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     res: Result = job.result(wait=0)
@@ -87,7 +87,7 @@ def test_failed_transpilation(failed_transpilation_job: Mocker) -> None:
 
 def test_failed_execution(failed_execution_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     res: Result = job.result(wait=0)
@@ -99,7 +99,7 @@ def test_failed_execution(failed_execution_job: Mocker) -> None:
 
 def test_cancel_job(cancellable_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     job = execute(c, backend)
     job.cancel()
@@ -112,7 +112,7 @@ def test_cancel_job(cancellable_job: Mocker) -> None:
 
 def test_failed_server_side_validation(failed_validation_job: Mocker) -> None:
     c = QuantumCircuit(1, 1)
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
     with pytest.raises(AliceBobApiException):
         execute(c, backend)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,10 +1,10 @@
 # pylint: disable=unused-argument
 
-from qiskit_alice_bob_provider import AliceBobProvider
+from qiskit_alice_bob_provider import AliceBobRemoteProvider
 
 
 def test_list_backends(mocked_targets) -> None:
-    provider = AliceBobProvider(api_key='foo')
+    provider = AliceBobRemoteProvider(api_key='foo')
     backends = provider.backends()
     for backend in backends:
         assert backend.name in str(backend)


### PR DESCRIPTION
We recently introduced a version of the provider handling the local simulation of cat qubits. These local simulations can be accessed using the `AliceBobLocalProvider`. 

To make sure users understand the difference between the local provider and the remote one, targeting the Alice & Bob endpoints, this PR  renames `AliceBobProvider`, `AliceBobBackends` and `AliceBobJobs` to include `Remote` so we can better differentiate them from local.

These changes were tested, including with the integration tests. I also made sure the README provided code was properly working.