### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qiskit_alice_bob_provider"
 authors = [
     {name = "Alice & Bob Software Team"},
 ]
-version = "0.2.0"
+version = "0.2.1"
 description = "Provider for running Qiskit circuits on Alice & Bob QPUs and simulators"
 readme = "README.md"
 license = {text = "Apache 2.0"}


### PR DESCRIPTION
As we recently merged the changes to our remote class names and implemented the new backend naming convention, this PR introduces a new patch version for a release on pypi.

Safe to revert.