### PR TITLE
local: use average_nb_photons instead of alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ used in this paper.
 It does not represent the current performance of Alice & Bob's cat qubits.
 
 The example below schedules and simulates a Bell state preparation circuit on
-a `EMU:6Q:PHYSICAL_CATS` processor, for different values of parameters `alpha` and
-`kappa_2`.
+a `EMU:6Q:PHYSICAL_CATS` processor, for different values of parameters
+`average_nb_photons` and `kappa_2`.
 
 ```python
 from qiskit_alice_bob_provider import AliceBobLocalProvider
@@ -90,7 +90,7 @@ circ.measure(0, 0)
 circ.measure(1, 1)
 
 # Default 6-qubit QPU with the ratio of memory dissipation rates set to
-# k1/k2=1e-5 and cat amplitude alpha set to 4.
+# k1/k2=1e-5 and cat size, average_nb_photons, set to 16.
 backend = provider.get_backend('EMU:6Q:PHYSICAL_CATS')
 
 print(transpile(circ, backend).draw())
@@ -99,8 +99,10 @@ print(transpile(circ, backend).draw())
 print(execute(circ, backend, shots=100000).result().get_counts())
 # {'11': 49823, '00': 50177}
 
-# Changing the cat amplitude from 4 (default) to 2 and k1/k2 to 1e-2.
-backend = provider.get_backend('EMU:6Q:PHYSICAL_CATS', alpha=2, kappa_2=1e4)
+# Changing the cat size from 16 (default) to 4 and k1/k2 to 1e-2.
+backend = provider.get_backend(
+    'EMU:6Q:PHYSICAL_CATS', average_nb_photons=4, kappa_2=1e4
+)
 print(execute(circ, backend, shots=100000).result().get_counts())
 # {'01': 557, '11': 49422, '10': 596, '00': 49425}
 ```

--- a/qiskit_alice_bob_provider/local/provider.py
+++ b/qiskit_alice_bob_provider/local/provider.py
@@ -18,6 +18,7 @@ from functools import partial
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
+import numpy as np
 from qiskit.providers import BackendV2, ProviderV1
 
 from ..processor.interpolated_cat import InterpolatedCatProcessor
@@ -57,6 +58,7 @@ class AliceBobLocalProvider(ProviderV1):
             self.build_from_serialized,
             file_path=str(_PARENT_DIR / 'resources' / 'lescanne_2020.json'),
             name='EMU:1Q:LESCANNE_2020',
+            average_nb_photons=4,
         )
         self._backends = [func() for func in self._backend_builders.values()]
 
@@ -87,7 +89,7 @@ class AliceBobLocalProvider(ProviderV1):
         n_qubits: int = 5,
         kappa_1: float = 100,
         kappa_2: float = 10_000_000,
-        alpha: float = 4,
+        average_nb_photons: float = 16,
         clock_cycle: float = 1e-9,
         coupling_map: Optional[List[Tuple[int, int]]] = None,
         name: Optional[str] = None,
@@ -103,7 +105,7 @@ class AliceBobLocalProvider(ProviderV1):
                 n_qubits=n_qubits,
                 kappa_1=kappa_1,
                 kappa_2=kappa_2,
-                alpha=alpha,
+                alpha=np.sqrt(average_nb_photons),
                 clock_cycle=clock_cycle,
                 coupling_map=coupling_map,
             ),
@@ -114,7 +116,7 @@ class AliceBobLocalProvider(ProviderV1):
         self,
         file_path: str,
         clock_cycle: float = 1e-9,
-        alpha: float = 2,
+        average_nb_photons: float = 16,
         name: Optional[str] = None,
     ) -> ProcessorSimulator:
         """Build a backend simulating a cat qubit based quantum processor
@@ -127,7 +129,7 @@ class AliceBobLocalProvider(ProviderV1):
             processor=InterpolatedCatProcessor(
                 serialized_processor=serialized,
                 clock_cycle=clock_cycle,
-                alpha=alpha,
+                alpha=np.sqrt(average_nb_photons),
             ),
             name=name,
         )

--- a/tests/local/test_provider.py
+++ b/tests/local/test_provider.py
@@ -1,4 +1,10 @@
+import pytest
+
+from qiskit_alice_bob_provider.local.backend import ProcessorSimulator
 from qiskit_alice_bob_provider.local.provider import AliceBobLocalProvider
+from qiskit_alice_bob_provider.processor.physical_cat import (
+    PhysicalCatProcessor,
+)
 
 
 def test_get_backends() -> None:
@@ -10,3 +16,13 @@ def test_get_backends() -> None:
     backends = ab.backends('EMU:6Q:PHYSICAL_CATS')
     assert len(backends) == 1
     assert ab.get_backend('EMU:6Q:PHYSICAL_CATS').name == backends[0].name
+
+
+# pylint: disable=protected-access
+def test_get_backend_change_nbar() -> None:
+    ab = AliceBobLocalProvider()
+    backend = ab.get_backend('EMU:6Q:PHYSICAL_CATS', average_nb_photons=9)
+    assert isinstance(backend, ProcessorSimulator)
+    proc = backend.target.durations()._proc
+    assert isinstance(proc, PhysicalCatProcessor)
+    assert proc._alpha == pytest.approx(3.0)


### PR DESCRIPTION
This is consistent with the remote package.