### PR TITLE
fix(sk_synthesis): Ignore cswap gates.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qiskit_alice_bob_provider"
 authors = [
     {name = "Alice & Bob Software Team"},
 ]
-version = "0.5.1"
+version = "0.5.2"
 description = "Provider for running Qiskit circuits on Alice & Bob QPUs and simulators"
 readme = "README.md"
 license = {text = "Apache 2.0"}

--- a/qiskit_alice_bob_provider/plugins/sk_synthesis.py
+++ b/qiskit_alice_bob_provider/plugins/sk_synthesis.py
@@ -78,6 +78,7 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
                 'delay',
                 'cz',
                 'ccz',
+                'cswap',
             }:
                 continue
             if instr.num_qubits == 1:
@@ -97,7 +98,15 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
         # List gates to synthesize (all gates except basis gates)
         synth_gates: Set[str] = set()
         for name, instr in get_standard_gate_name_mapping().items():
-            if name in {'measure', 'measure_x', 'reset', 'delay', 'cz', 'ccz'}:
+            if name in {
+                'measure',
+                'measure_x',
+                'reset',
+                'delay',
+                'cz',
+                'ccz',
+                'cswap',
+            }:
                 continue
             synth_gates.add(name)
         synth_gates -= set(discrete_basis_gates)


### PR DESCRIPTION
CSwap should be neither a target or input of the synthesis, simply being then translated later in the transpilation pass