### PR TITLE
fix: Skip reset for the SK-Synthesis

### DIFF
--- a/qiskit_alice_bob_provider/plugins/sk_synthesis.py
+++ b/qiskit_alice_bob_provider/plugins/sk_synthesis.py
@@ -75,6 +75,7 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
             if len(instr.params) != 0 or instr.name in {
                 'measure',
                 'measure_x',
+                'reset',
                 'delay',
                 'cz',
                 'ccz',


### PR DESCRIPTION
This bug was highlighted after the update to the transpilation pass. It appears the remote target including the logical ones include the reset gate in their list of accepted input gates.

This commit makes it so we don't try to compute approximations for the reset gate.