### PR TITLE
Remove qiskit-terra explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,9 @@ urls = {Homepage = "https://github.com/Alice-Bob-SW/qiskit-alice-bob-provider", 
 requires-python = ">=3.7"
 dependencies = [
     "requests",
-    "qiskit<0.45",
     # >=0.24.0: required for correct handling of durations
     # <0.45.0: this version introduces many API changes that we need to integrate
-    "qiskit-terra>=0.24.0,<0.45.0",
+    "qiskit>=0.43,<0.45",
     # <0.13.0: qiskit-aer has become irritatingly slow in this release.
     # It especially shows in https://github.com/Alice-Bob-SW/emulation-examples/blob/main/3_error_detection_on_physical_qubits.ipynb
     "qiskit-aer<0.13.0",


### PR DESCRIPTION
`qiskit-terra` is part of the `qiskit<1` meta-package. Keeping the double-dependency is redundant and forces to keep them in track.

`qiskit-terra>=0.24` is equivalent to `qiskit>=0.43`.

| Qiskit Metapackage Version | qiskit-terra | qiskit-aer | qiskit-ibmq-provider | Release Date |
|:--------------------------:|:------------:|:----------:|:------------:|:------------:|
| 0.43.0                     | 0.24.0       |  0.12.0     |  0.20.2           | 2023-05-04   |
