### PR TITLE
[0.7.0] Limit Python versions to >=3.8 <3.12 and alert on outdated provider versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ classifiers=[
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 urls = {Homepage = "https://github.com/Alice-Bob-SW/qiskit-alice-bob-provider", "Alice & Bob" = "https://alice-bob.com/"}
-requires-python = ">=3.7"
+requires-python = ">=3.8, <3.12"
 dependencies = [
     "requests",
     "qiskit<0.45",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qiskit_alice_bob_provider"
 authors = [
     {name = "Alice & Bob Software Team"},
 ]
-version = "0.6.0"
+version = "0.7.0"
 description = "Provider for running Qiskit circuits on Alice & Bob QPUs and simulators"
 readme = "README.md"
 license = {text = "Apache 2.0"}
@@ -51,14 +51,18 @@ dev = [
     "flake8>=5.0.4",
     "flake8-quotes==3.3.2",
     "isort>=5.11.5",
+    "mock==5.1.0",
     "mypy==1.0.0",
     "mypy-extensions==1.0.0",
     "pre-commit>=2.21.0",
     "pylint==2.16.1",
     "pytest==7.2.1",
     "requests-mock==1.10.0",
-    "types-requests==2.30.0.0",
+    "traitlets==5.14.3",
     "twine==4.0.2",
+    "types-mock==5.1.0",
+    "types-setuptools==70.0.0.20240524",
+    "types-requests==2.30.0.0",
     "build==0.10.0"
 ]
 

--- a/qiskit_alice_bob_provider/remote/api/version.py
+++ b/qiskit_alice_bob_provider/remote/api/version.py
@@ -1,0 +1,33 @@
+import logging
+from enum import Enum
+
+import requests
+from pkg_resources import get_distribution
+
+PROVIDER_PYPI_URL = 'https://pypi.org/pypi/qiskit-alice-bob-provider/json'
+
+
+class ProviderStatus(Enum):
+    LATEST = 'LATEST'
+    OUTDATED = 'OUTDATED'
+    UNKNOWN = 'UNKNOWN'
+
+
+def get_provider_status() -> ProviderStatus:
+    """Query the Pypi API to compare the latest release of the Qiskit provider
+    with the current installation and return the update status
+    (latest, outdated, unknown)."""
+    try:
+        pypi_response = requests.get(url=PROVIDER_PYPI_URL, timeout=1.0)
+        assert pypi_response.status_code == 200
+        pypi_version = pypi_response.json()['info']['version']
+    # pylint: disable=broad-exception-caught
+    except Exception as e:
+        logging.exception(e)
+        return ProviderStatus.UNKNOWN
+
+    installed_version = get_distribution('qiskit_alice_bob_provider').version
+
+    if pypi_version == installed_version:
+        return ProviderStatus.LATEST
+    return ProviderStatus.OUTDATED

--- a/qiskit_alice_bob_provider/remote/provider.py
+++ b/qiskit_alice_bob_provider/remote/provider.py
@@ -14,10 +14,16 @@
 #    limitations under the License.
 ##############################################################################
 
+import logging
 from typing import List, Optional
 
 from qiskit.providers import BackendV2, ProviderV1
 from qiskit.providers.providerutils import filter_backends
+
+from qiskit_alice_bob_provider.remote.api.version import (
+    ProviderStatus,
+    get_provider_status,
+)
 
 from .api.client import ApiClient
 from .api.targets import list_targets
@@ -51,6 +57,18 @@ class AliceBobRemoteProvider(ProviderV1):
         self._backends = []
         for ab_target in list_targets(client):
             self._backends.append(AliceBobRemoteBackend(client, ab_target))
+
+        provider_status = get_provider_status()
+        if provider_status == ProviderStatus.UNKNOWN:
+            logging.warning(
+                'Could not determine the latest version of the provider. '
+                'Your installation may be outdated.'
+            )
+        elif provider_status == ProviderStatus.OUTDATED:
+            logging.warning(
+                'A new version of the provider is available. Install it with '
+                '"pip install -U qiskit-alice-bob-provider".'
+            )
 
     def get_backend(
         self, name=None, verbose=True, **kwargs

--- a/tests/remote/test_version.py
+++ b/tests/remote/test_version.py
@@ -1,0 +1,81 @@
+from mock import MagicMock, patch
+from pkg_resources import Distribution
+from requests_mock.mocker import Mocker
+
+from qiskit_alice_bob_provider.remote.api.version import (
+    PROVIDER_PYPI_URL,
+    ProviderStatus,
+    get_provider_status,
+)
+
+
+@patch(
+    'qiskit_alice_bob_provider.remote.api.version.get_distribution',
+    wraps=lambda _: Distribution(version='1.2.0'),
+)
+def test_get_provider_status_latest(
+    get_distribution_mock: MagicMock,
+    requests_mock: Mocker,
+) -> None:
+    requests_mock.register_uri(
+        'GET',
+        PROVIDER_PYPI_URL,
+        json={
+            'info': {
+                'author': 'Alice & Bob Software Team',
+                'keywords': 'Qiskit, Alice & Bob, Quantum, SDK',
+                'license': 'Apache 2.0',
+                'name': 'qiskit-alice-bob-provider',
+                'summary': (
+                    'Provider for running Qiskit circuits on '
+                    'Alice & Bob QPUs and simulators'
+                ),
+                'version': '1.2.0',
+            },
+        },
+    )
+
+    status = get_provider_status()
+    get_distribution_mock.assert_called_once()
+    assert status == ProviderStatus.LATEST
+
+
+@patch(
+    'qiskit_alice_bob_provider.remote.api.version.get_distribution',
+    wraps=lambda _: Distribution(version='1.2.0'),
+)
+def test_get_provider_status_outdated(
+    get_distribution_mock: MagicMock,
+    requests_mock: Mocker,
+) -> None:
+    requests_mock.register_uri(
+        'GET',
+        PROVIDER_PYPI_URL,
+        json={
+            'info': {
+                'author': 'Alice & Bob Software Team',
+                'keywords': 'Qiskit, Alice & Bob, Quantum, SDK',
+                'license': 'Apache 2.0',
+                'name': 'qiskit-alice-bob-provider',
+                'summary': (
+                    'Provider for running Qiskit circuits on '
+                    'Alice & Bob QPUs and simulators'
+                ),
+                'version': '1.2.1',
+            },
+        },
+    )
+
+    status = get_provider_status()
+    get_distribution_mock.assert_called_once()
+    assert status == ProviderStatus.OUTDATED
+
+
+def test_get_provider_status_pypi_exception(
+    requests_mock: Mocker,
+) -> None:
+    requests_mock.register_uri(
+        'GET', PROVIDER_PYPI_URL, json={}, status_code=404
+    )
+
+    assert get_provider_status() == ProviderStatus.UNKNOWN


### PR DESCRIPTION
Two changes in this PR:
1) Make us more restrictive about the allowed versions of Python (>=3.8 ; <3.12)
3.7 is no longer supported by Numpy on ARM architectures in this version. Therefore these users can not install the provider. As 3.7 is now officially deprecated by the Python team, we want to move away from it now to avoid more deprecation issues in the future.
3.12 requires some refactoring and dependency upgrades to come out. This is to be done in the near future by us.

2) Send a warning to the user if he uses a provider different version than the latest one released on Pypi, when instancing the remote provider. This is because our remote API may release some important changes to the user experience and we really want to enforce this lib to be up to date when interacting with Felis Cloud.