### PR TITLE
Add Python3.12 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: ["macOS-latest"]
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
       matrix:
         # We skip Python 3.7 has Windows needs to rebuild it, but its specs are
         # too low to do it...
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: ["windows-latest"]
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,11 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 urls = {Homepage = "https://github.com/Alice-Bob-SW/qiskit-alice-bob-provider", "Alice & Bob" = "https://alice-bob.com/"}
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 dependencies = [
     "requests",
     # >=0.24.0: required for correct handling of durations


### PR DESCRIPTION
This PR allows `Python3.12` to be used with qiskit. This was done in preparation of https://github.com/Alice-Bob-SW/qiskit-alice-bob-provider/issues/38.