### PR TITLE
feat: Support Qiskit 1.0+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,25 +58,6 @@ jobs:
         run: make install
       - name: Install and Run Tests
         run: make unit-tests
-  tests-old-qiskit:
-    name: tests-old-qiskit
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ['3.10']
-        os: ["ubuntu-latest"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Deps
-        run: make install
-      - name: Downgrade Qiskit
-        run: venv/bin/pip install qiskit==0.43.0
-      - name: Install and Run Tests
-        run: make unit-tests
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,9 @@ dependencies = [
     "ipywidgets",
     "pydantic>=2.0",
     "requests",
-    # <0.45.0: this version introduces many API changes that we need to integrate
-    "qiskit>=0.43,<0.45",
-    # <0.13.0: qiskit-aer has become irritatingly slow in this release.
-    # It especially shows in https://github.com/Alice-Bob-SW/emulation-examples/blob/main/3_error_detection_on_physical_qubits.ipynb
-    "qiskit-aer<0.13.0",
-    "qiskit-qir-alice-bob-fork==0.3.2rc0",
+    "qiskit>=1.0, <1.2",
+    "qiskit-aer<0.16.0",
+    "qiskit-qir-alice-bob-fork==0.5.0rc0",
     "tenacity"
 ]
 
@@ -65,6 +62,9 @@ dev = [
     "types-setuptools==70.0.0.20240524",
     "types-requests==2.30.0.0"
 ]
+
+[project.entry-points."qiskit.transpiler.scheduling"]
+ab_asap = "qiskit_alice_bob_provider.plugins.ab_asap:AliceBobASAPSchedulingPlugin"
 
 [project.entry-points."qiskit.transpiler.translation"]
 state_preparation = "qiskit_alice_bob_provider.plugins.state_preparation:StatePreparationPlugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qiskit_alice_bob_provider"
 authors = [
     {name = "Alice & Bob Software Team"},
 ]
-version = "0.7.2"
+version = "1.0.0rc0"
 description = "Provider for running Qiskit circuits on Alice & Bob QPUs and simulators"
 readme = "README.md"
 license = {text = "Apache 2.0"}

--- a/qiskit_alice_bob_provider/local/patch/local_noise_pass.py
+++ b/qiskit_alice_bob_provider/local/patch/local_noise_pass.py
@@ -12,7 +12,6 @@
 """
 Local noise addition pass.
 """
-from copy import deepcopy
 from typing import Callable, Iterable, Optional, Sequence, Union
 
 from qiskit.circuit import Instruction, QuantumCircuit
@@ -131,7 +130,7 @@ class LocalNoisePass(TransformationPass):
 
             # Note from Alice & Bob: the only change is to use a copy of
             # node.op with the classical conditioning removed.
-            node_op_without_cond = deepcopy(node.op)
+            node_op_without_cond = node.op.to_mutable()
             node_op_without_cond.condition = None
 
             # If appending re-apply original op node first

--- a/qiskit_alice_bob_provider/local/proc_to_qiskit.py
+++ b/qiskit_alice_bob_provider/local/proc_to_qiskit.py
@@ -17,10 +17,10 @@
 from typing import Dict, List
 
 from qiskit.circuit import Delay, Instruction, Measure, Parameter
+from qiskit.circuit.library import Initialize
 from qiskit.circuit.library.standard_gates import (
     get_standard_gate_name_mapping,
 )
-from qiskit.extensions.quantum_initializer import Initialize
 
 from ..custom_instructions import MeasureX
 from ..processor.description import InstructionProperties

--- a/qiskit_alice_bob_provider/local/quantum_errors.py
+++ b/qiskit_alice_bob_provider/local/quantum_errors.py
@@ -21,9 +21,8 @@ from qiskit.circuit.equivalence_library import (
     EquivalenceLibrary,
     SessionEquivalenceLibrary,
 )
-from qiskit.circuit.library import IGate
+from qiskit.circuit.library import IGate, Initialize
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.extensions.quantum_initializer import Initialize
 from qiskit.quantum_info import Chi
 from qiskit.transpiler import TransformationPass
 from qiskit_aer.noise import pauli_error
@@ -77,9 +76,8 @@ class _MeasureMarkerGate(IGate):
     instruction's quantum error after the marker gate. This is a trick that we
     may not need in the future, depending on the evolution of Qiskit."""
 
-    def __init__(self, name: str, label: Optional[str] = None):
+    def __init__(self, label: Optional[str] = None):
         super().__init__(label=label)
-        self.name = name
 
     def add_equivalence(self, library: EquivalenceLibrary) -> None:
         """Add an implementation of this marker gate to an equivalence library
@@ -89,18 +87,20 @@ class _MeasureMarkerGate(IGate):
         library.add_equivalence(self, circuit)
 
 
+# pylint: disable=too-many-ancestors
 class _MxMarkerGate(_MeasureMarkerGate):
     """A virtual gate that is inserted before every MeasureX"""
 
     def __init__(self, label: Optional[str] = None):
-        super().__init__(name='measure_x_marker', label=label)
+        super().__init__(label=label)
 
 
+# pylint: disable=too-many-ancestors
 class _MzMarkerGate(_MeasureMarkerGate):
     """A virtual gate that is inserted before every MeasureZ"""
 
     def __init__(self, label: Optional[str] = None):
-        super().__init__(name='measure_z_marker', label=label)
+        super().__init__(label=label)
 
 
 _marker_gate_types: Dict[str, type] = {
@@ -172,7 +172,7 @@ def _transpilation_pass_from_instruction(
                 processor=processor,
                 instr_properties=instruction,
             ),
-            op_types=[qiskit_instruction.__class__],
+            op_types=[qiskit_instruction.base_class],
             method='append',
         )
 

--- a/qiskit_alice_bob_provider/plugins/ab_asap.py
+++ b/qiskit_alice_bob_provider/plugins/ab_asap.py
@@ -1,0 +1,105 @@
+##############################################################################
+# Copyright 2023 Alice & Bob
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+
+from typing import cast
+
+from qiskit.transpiler import PassManager, PassManagerConfig
+from qiskit.transpiler.instruction_durations import InstructionDurations
+from qiskit.transpiler.passes import TimeUnitConversion
+from qiskit.transpiler.preset_passmanagers.common import generate_scheduling
+from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
+
+from qiskit_alice_bob_provider.local.instruction_durations import (
+    ProcessorInstructionDurations,
+)
+
+
+class CustomTimeUnitConversion(TimeUnitConversion):
+    """
+    This is a replacement of the base TimeUnitConversion pass to handle the
+    ProcessorInstructionDurations object created for Alice & Bob backends.
+
+    The pass overrides the _update_inst_durations method to apply the base
+    durations from Alice & Bob's ProcessorInstructionDuration instead of
+    the generic InstructionDurations class from Qiskit.
+    """
+
+    def _update_inst_durations(self, dag) -> InstructionDurations:
+        """Update instruction durations with circuit information.
+        If the dag contains gate calibrations and no instruction durations were
+        provided through the target or as a standalone input, the circuit
+        calibration durations will be used. The priority order for
+        instruction durations is: target > standalone > circuit.
+        """
+        if not isinstance(self.inst_durations, ProcessorInstructionDurations):
+            return self.inst_durations
+
+        # pylint: disable=protected-access
+        circ_durations = ProcessorInstructionDurations(
+            self.inst_durations._proc
+        )
+
+        if dag.calibrations:
+            cal_durations = []
+            for gate, gate_cals in dag.calibrations.items():
+                for (qubits, parameters), schedule in gate_cals.items():
+                    cal_durations.append(
+                        (gate, qubits, parameters, schedule.duration)
+                    )
+            circ_durations.update(cal_durations, circ_durations.dt)
+
+        if self._durations_provided:
+            # We cast dt to float for mypy, to match the signature required by
+            # update(), but the real type of dt is indeed Optional[float].
+            circ_durations.update(
+                self.inst_durations,
+                cast(float, getattr(self.inst_durations, 'dt', None)),
+            )
+
+        return circ_durations
+
+
+class AliceBobASAPSchedulingPlugin(PassManagerStagePlugin):
+    """A pass manager to compute scheduling of a circuit to run on
+    Alice & Bob's local backends with the ASAP strategy."""
+
+    def pass_manager(
+        self,
+        pass_manager_config: PassManagerConfig,
+        optimization_level=None,
+    ) -> PassManager:
+        pm = generate_scheduling(
+            instruction_durations=pass_manager_config.instruction_durations,
+            scheduling_method='asap',
+            timing_constraints=pass_manager_config.timing_constraints,
+            inst_map=pass_manager_config.inst_map,
+            target=pass_manager_config.target,
+        )
+
+        # pylint: disable=protected-access
+        for task in pm._tasks:
+            for i, subtask in enumerate(task):
+                # Substitue the default TimeUnitConversion with our
+                # custom implementation.
+                if isinstance(subtask, TimeUnitConversion):
+                    pm.replace(
+                        i,
+                        CustomTimeUnitConversion(
+                            target=pass_manager_config.target
+                        ),
+                    )
+
+        return pm

--- a/qiskit_alice_bob_provider/plugins/sk_synthesis.py
+++ b/qiskit_alice_bob_provider/plugins/sk_synthesis.py
@@ -122,6 +122,7 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
         # Use above SK approximations by default
         pass_manager_config.unitary_synthesis_plugin_config = {
             'basic_approximations': approximations,
+            'basis_gates': discrete_basis_gates,
             **(pass_manager_config.unitary_synthesis_plugin_config or {}),
         }
 
@@ -135,25 +136,25 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
         # SolovayKitaevSynthesis plugin) with the gates to synthesize and basis
         # gates computed above.
         if pass_manager_config.unitary_synthesis_method == 'sk':
-            for passess in pm.passes():
-                for passes in passess.values():
-                    for p in passes:
-                        if (
-                            isinstance(p, UnitarySynthesis)
-                            and p.method == 'sk'
-                        ):
-                            # There is no option to manually set the gates to
-                            # synthesize in UnitarySynthesis, and the default
-                            # _synth_gates is just 'unitary'!
-                            # pylint: disable=protected-access
-                            p._synth_gates = synth_gates
-                            # Can't pass basis gates in
-                            # unitary_synthesis_plugin_config because overriden
-                            # by global basis_gates.
-                            # This seems to be a Qiskit bug (why give the
-                            # possibility to specify basis gates in the plugin
-                            # config if that was not the intent?)
-                            # pylint: disable=protected-access
-                            p._basis_gates = discrete_basis_gates
+            # pylint: disable=protected-access
+            for task in pm._tasks:
+                for subtask in task:
+                    if (
+                        isinstance(subtask, UnitarySynthesis)
+                        and subtask.method == 'sk'
+                    ):
+                        # There is no option to manually set the gates to
+                        # synthesize in UnitarySynthesis, and the default
+                        # _synth_gates is just 'unitary'!
+                        # pylint: disable=protected-access
+                        subtask._synth_gates = synth_gates
+                        # Can't pass basis gates in
+                        # unitary_synthesis_plugin_config because overriden
+                        # by global basis_gates.
+                        # This seems to be a Qiskit bug (why give the
+                        # possibility to specify basis gates in the plugin
+                        # config if that was not the intent?)
+                        # pylint: disable=protected-access
+                        subtask._basis_gates = discrete_basis_gates
 
         return pm

--- a/qiskit_alice_bob_provider/remote/backend.py
+++ b/qiskit_alice_bob_provider/remote/backend.py
@@ -70,16 +70,6 @@ class AliceBobRemoteBackend(BackendV2):
         This function is called before we start the circuit translation,
         and we therefore also use it to inform that we are starting this step.
         """
-        # The first stage to display is Qiskit's inner transpilation step.
-        # It is done before calling backend.run() or creating an instance
-        # of AliceBobRemoteJob().
-        # Therefore, we must initialize the new line display here.
-        display_new_line()
-
-        if self._verbose:
-            display_current_line(
-                'Translating circuit to supported operations.'
-            )
         return self._translation_plugin
 
     def update_options(self, option_updates: Dict[str, Any]) -> Options:
@@ -115,6 +105,7 @@ class AliceBobRemoteBackend(BackendV2):
                 'Please provide an instance of QuantumCircuit.'
             )
         if self._verbose:
+            display_new_line()
             display_current_line('Sending circuit to the API...')
         options = self.update_options(kwargs)
         input_params = _ab_input_params_from_options(options)

--- a/qiskit_alice_bob_provider/remote/qir_to_qiskit.py
+++ b/qiskit_alice_bob_provider/remote/qir_to_qiskit.py
@@ -27,6 +27,7 @@ from qiskit.circuit.library import (
     CXGate,
     CZGate,
     HGate,
+    Initialize,
     RXGate,
     RYGate,
     RZGate,
@@ -39,7 +40,6 @@ from qiskit.circuit.library import (
     YGate,
     ZGate,
 )
-from qiskit.extensions.quantum_initializer import Initialize
 from qiskit.transpiler import Target
 
 from ..custom_instructions import MeasureX

--- a/tests/local/test_backend.py
+++ b/tests/local/test_backend.py
@@ -1,8 +1,8 @@
 from typing import List
 
 import numpy as np
-from qiskit import QuantumCircuit, execute, transpile
-from qiskit.extensions.quantum_initializer import Initialize
+from qiskit import QuantumCircuit, transpile
+from qiskit.circuit.library import Initialize
 
 from qiskit_alice_bob_provider.local.backend import ProcessorSimulator
 from qiskit_alice_bob_provider.processor.physical_cat import (
@@ -39,7 +39,8 @@ def test_set_execution_backend_options() -> None:
     backend = ProcessorSimulator(PhysicalCatProcessor())
     backend.set_options(shots=7)
     assert backend.options['shots'] == 7
-    assert sum(execute(circ, backend).result().get_counts().values()) == 7
+    transpiled = transpile(circ, backend)
+    assert sum(backend.run(transpiled).result().get_counts().values()) == 7
 
 
 def test_translation_plugin() -> None:

--- a/tests/local/test_proc_to_qiskit.py
+++ b/tests/local/test_proc_to_qiskit.py
@@ -1,7 +1,6 @@
 import pytest
 from qiskit.circuit import Delay, Instruction, Parameter
-from qiskit.circuit.library import CXGate, RYGate, XGate
-from qiskit.extensions.quantum_initializer import Initialize
+from qiskit.circuit.library import CXGate, Initialize, RYGate, XGate
 
 from qiskit_alice_bob_provider.custom_instructions import MeasureX
 from qiskit_alice_bob_provider.local.proc_to_qiskit import (

--- a/tests/local/test_readout_errors.py
+++ b/tests/local/test_readout_errors.py
@@ -1,5 +1,5 @@
 import pytest
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit
 
 from qiskit_alice_bob_provider.local.backend import ProcessorSimulator
 from qiskit_alice_bob_provider.local.readout_errors import (
@@ -25,14 +25,14 @@ def test_one_readout_error() -> None:
     circ.initialize('++')
     circ.measure_x(0, 0)
     circ.measure_x(1, 1)
-    counts = execute(circ, backend, shots=1).result().get_counts()
+    counts = backend.run(circ, shots=1).result().get_counts()
     assert counts.keys() == {'01'}
 
     circ = QuantumCircuit(2, 2)
     circ.initialize('--')
     circ.measure_x(0, 0)
     circ.measure_x(1, 1)
-    counts = execute(circ, backend, shots=1).result().get_counts()
+    counts = backend.run(circ, shots=1).result().get_counts()
     assert counts.keys() == {'01'}
 
 
@@ -44,14 +44,14 @@ def test_all_to_all_one_readout_error() -> None:
     circ.initialize('++')
     circ.measure_x(0, 0)
     circ.measure_x(1, 1)
-    counts = execute(circ, backend, shots=1).result().get_counts()
+    counts = backend.run(circ, shots=1).result().get_counts()
     assert counts.keys() == {'11'}
 
     circ = QuantumCircuit(2, 2)
     circ.initialize('--')
     circ.measure_x(0, 0)
     circ.measure_x(1, 1)
-    counts = execute(circ, backend, shots=1).result().get_counts()
+    counts = backend.run(circ, shots=1).result().get_counts()
     assert counts.keys() == {'11'}
 
 
@@ -63,13 +63,13 @@ def test_conflicting_readout_errors() -> None:
     circ = QuantumCircuit(1, 1)
     circ.initialize('+')
     circ.measure_x(0, 0)
-    counts = execute(circ, backend, shots=1).result().get_counts()
+    counts = backend.run(circ, shots=1).result().get_counts()
     assert counts.keys() == {'1'}
 
     circ = QuantumCircuit(1, 1)
     circ.initialize('-')
     circ.measure_x(0, 0)
-    counts = execute(circ, backend, shots=1).result().get_counts()
+    counts = backend.run(circ, shots=1).result().get_counts()
     assert counts.keys() == {'1'}
 
 

--- a/tests/local/test_scheduling.py
+++ b/tests/local/test_scheduling.py
@@ -2,7 +2,7 @@ from typing import Iterator, Tuple
 
 import pytest
 from qiskit import QuantumCircuit, transpile
-from qiskit.extensions.quantum_initializer import Initialize
+from qiskit.circuit.library import Initialize
 
 from qiskit_alice_bob_provider.local.backend import ProcessorSimulator
 from qiskit_alice_bob_provider.processor.description import (

--- a/tests/plugins/test_state_preparation.py
+++ b/tests/plugins/test_state_preparation.py
@@ -3,7 +3,7 @@ from typing import List
 import pytest
 from qiskit import QuantumCircuit
 from qiskit.circuit import ClassicalRegister, QuantumRegister
-from qiskit.extensions.quantum_initializer import Initialize
+from qiskit.circuit.library import Initialize
 from qiskit.transpiler import PassManager, PassManagerConfig, TranspilerError
 
 from qiskit_alice_bob_provider.local import AliceBobLocalProvider
@@ -105,7 +105,7 @@ def test_missing_prep() -> None:
     c.reset(1)
     c.y(1)
     c.initialize('+', 2)
-    c.cnot(1, 2)
+    c.cx(1, 2)
     c.measure(2, 0)
     new_c = pm.run(c)
     expected = c.count_ops()

--- a/tests/remote/test_against_real_server.py
+++ b/tests/remote/test_against_real_server.py
@@ -15,7 +15,7 @@
 ##############################################################################
 
 import pytest
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit, transpile
 
 from qiskit_alice_bob_provider import AliceBobRemoteProvider
 
@@ -37,6 +37,7 @@ def test_happy_path(base_url: str, api_key: str) -> None:
     backend = provider.get_backend(
         'EMU:1Q:LESCANNE_2020', average_nb_photons=6.0
     )
-    job = execute(c, backend, shots=100)
+    transpiled = transpile(c, backend)
+    job = backend.run(transpiled, shots=100)
     res = job.result()
     res.get_counts()


### PR DESCRIPTION
This PR introduces fixes and changes on the Qiskit Alice & Bob provider to make it work with Qiskit 1.0 and higher.
We aim to offer the same interfaces as in the previous version, however, the new release can not be backward compatible with versions earlier than 1.0.

It has been tested on the Felis sample notebooks, against sampler benchmarks and on the remote targets.

This PR releases the package as a pre-release for version 1.0.0, to start testing it and prepare the update to our documentation.