### PR TITLE
test: get multiple backends with options does not affect default options

### DIFF
--- a/tests/local/test_provider.py
+++ b/tests/local/test_provider.py
@@ -26,3 +26,24 @@ def test_get_backend_change_nbar() -> None:
     proc = backend.target.durations()._proc
     assert isinstance(proc, PhysicalCatProcessor)
     assert proc._average_nb_photons == pytest.approx(9)
+
+
+def test_get_multiple_backends_with_options() -> None:
+    """
+    Test that getting multiple backends with different options does not affect
+    the default Processor options (but backend.options will remain the same
+    anyway for AliceBobLocalProvider).
+    """
+    provider = AliceBobLocalProvider()
+    default_backend = provider.get_backend('EMU:6Q:PHYSICAL_CATS')
+    proc1 = default_backend.target.durations()._proc
+    _ = provider.get_backend('EMU:6Q:PHYSICAL_CATS', average_nb_photons=6)
+    backend = provider.get_backend('EMU:6Q:PHYSICAL_CATS')
+    proc2 = backend.target.durations()._proc
+
+    # Ensure that the backend objects are different instances
+    assert default_backend is not backend
+    # Ensure that the Processor objects are different instances
+    assert proc1 is not proc2
+    # Ensure that the default Processor option didn't change
+    assert proc1._average_nb_photons == proc2._average_nb_photons

--- a/tests/remote/test_backend.py
+++ b/tests/remote/test_backend.py
@@ -52,6 +52,26 @@ def test_get_backend_with_options(mocked_targets) -> None:
     assert backend.options['average_nb_photons'] == 6.0
 
 
+def test_get_multiple_backends_with_options(mocked_targets) -> None:
+    """
+    Test that getting multiple backends with different options does not affect
+    the default backend options.
+    """
+    provider = AliceBobRemoteProvider(api_key='foo')
+    default_backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
+    _ = provider.get_backend(
+        'EMU:1Q:LESCANNE_2020', average_nb_photons=6, shots=10
+    )
+    backend = provider.get_backend('EMU:1Q:LESCANNE_2020')
+
+    # Ensure that the backend objects are different instances
+    assert default_backend is not backend
+    # Ensure that the options objects are different instances
+    assert default_backend.options is not backend.options
+    # Ensure that the default options are equal
+    assert default_backend.options == backend.options
+
+
 def test_get_backend_options_validation(mocked_targets) -> None:
     provider = AliceBobRemoteProvider(api_key='foo')
     with pytest.raises(ValueError):


### PR DESCRIPTION
Test added to avoid a shared reference issue with options, where calling `get_backend()` with options would change the default options for this backend.