### PR TITLE
fix: do not allow to pass A&B custom options to `backend.run()`

### DIFF
--- a/qiskit_alice_bob_provider/processor/utils.py
+++ b/qiskit_alice_bob_provider/processor/utils.py
@@ -14,10 +14,12 @@
 #    limitations under the License.
 ##############################################################################
 
+from inspect import signature
 from itertools import product
 from typing import Dict, List, Union
 
 import numpy as np
+from typing_extensions import Type
 
 
 def pauli_errors_to_chi(pauli_errors: Dict[str, float]) -> np.ndarray:
@@ -220,3 +222,9 @@ def tensor_errors(
     for (a_pauli, a_prob), (b_pauli, b_prob) in product(a.items(), b.items()):
         output[b_pauli + a_pauli] = a_prob * b_prob
     return output
+
+
+def get_init_params(cls: Type) -> List[str]:
+    """Get the names of the parameters of a class's __init__ method"""
+    init_signature = signature(cls.__init__)
+    return list(init_signature.parameters.keys())[1:]  # Skip 'self'

--- a/tests/local/test_backend.py
+++ b/tests/local/test_backend.py
@@ -1,10 +1,12 @@
 from typing import List
 
 import numpy as np
+import pytest
 from qiskit import QuantumCircuit, transpile
 from qiskit.circuit.library import Initialize
 
 from qiskit_alice_bob_provider.local.backend import ProcessorSimulator
+from qiskit_alice_bob_provider.processor.logical_cat import LogicalCatProcessor
 from qiskit_alice_bob_provider.processor.physical_cat import (
     PhysicalCatProcessor,
 )
@@ -41,6 +43,26 @@ def test_set_execution_backend_options() -> None:
     assert backend.options['shots'] == 7
     transpiled = transpile(circ, backend)
     assert sum(backend.run(transpiled).result().get_counts().values()) == 7
+
+
+def test_run_override_nbar_error() -> None:
+    """
+    Test that passing average_nb_photons option to backend.run() is not allowed
+    """
+    circ = QuantumCircuit(1, 1)
+    backend = ProcessorSimulator(PhysicalCatProcessor())
+    transpiled = transpile(circ, backend)
+    with pytest.raises(ValueError):
+        _ = backend.run(transpiled, shots=100, average_nb_photons=4)
+    with pytest.raises(ValueError):
+        _ = backend.run(transpiled, shots=100, kappa_1=4)
+
+    backend = ProcessorSimulator(LogicalCatProcessor())
+    transpiled = transpile(circ, backend)
+    with pytest.raises(ValueError):
+        _ = backend.run(transpiled, shots=100, average_nb_photons=4)
+    with pytest.raises(ValueError):
+        _ = backend.run(transpiled, shots=100, kappa_1=4)
 
 
 def test_translation_plugin() -> None:


### PR DESCRIPTION
The Alice & Bob custom options of Processors like `average_nb_photons` are not allowed for `backend.run()` with local provider because they will be ignored. They should be passed to `get_backend()` instead.