### PR TITLE
fix: issue when options are passed as numpy types

### DIFF
--- a/qiskit_alice_bob_provider/remote/backend.py
+++ b/qiskit_alice_bob_provider/remote/backend.py
@@ -16,6 +16,7 @@
 from copy import deepcopy
 from typing import Any, Dict
 
+import numpy as np
 from pydantic.alias_generators import to_camel, to_snake
 from qiskit import QuantumCircuit
 from qiskit.providers import BackendV2, Options
@@ -151,6 +152,8 @@ def _ab_input_params_from_options(options: Options) -> Dict:
         name = to_camel(snake_name)
         if name == 'shots':  # special case
             name = 'nbShots'
+        if isinstance(value, np.generic):
+            value = value.item()
         input_params[name] = value
     return input_params
 

--- a/tests/remote/test_backend.py
+++ b/tests/remote/test_backend.py
@@ -19,6 +19,7 @@
 from pathlib import Path
 from textwrap import dedent
 
+import numpy as np
 import pytest
 from qiskit import QiskitError, QuantumCircuit, transpile
 from qiskit.providers import Options
@@ -209,6 +210,12 @@ def test_ab_input_params_from_options() -> None:
     options = Options(shots=43, average_nb_photons=3.2, foo_hey='bar')
     params = _ab_input_params_from_options(options)
     assert params == {'nbShots': 43, 'averageNbPhotons': 3.2, 'fooHey': 'bar'}
+
+
+def test_ab_input_params_from_options_with_numpy() -> None:
+    options = Options(shots=43, average_nb_photons=np.int32(3), foo_hey='bar')
+    params = _ab_input_params_from_options(options)
+    assert params == {'nbShots': 43, 'averageNbPhotons': 3, 'fooHey': 'bar'}
 
 
 def test_translation_plugin_and_qir(mocked_targets) -> None:


### PR DESCRIPTION
When using the AliceBobRemoteProvider, the backend options are serialized as JSON to be sent to the API. In some cases, the user might provide some option values as numpy types (eg. `average_nb_photons=np.int32(4)`), which is not JSON serializable and therefore raises an error.

This fix aims to convert numpy scalar values to their corresponding native Python type before serialization. `value.item()` does just that.

Note that `numpy` is a dependency of `qiskit` so it does not have to be added to the package dependencies directly.