### PR TITLE
Feat: Support Control Flow Operators

### DIFF
--- a/qiskit_alice_bob_provider/local/instruction_durations.py
+++ b/qiskit_alice_bob_provider/local/instruction_durations.py
@@ -17,7 +17,14 @@
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
-from qiskit.circuit import Barrier, Delay, Instruction, Parameter, Qubit
+from qiskit.circuit import (
+    Barrier,
+    ControlFlowOp,
+    Delay,
+    Instruction,
+    Parameter,
+    Qubit,
+)
 from qiskit.transpiler.instruction_durations import (
     InstructionDurations,
     InstructionDurationsType,
@@ -76,6 +83,8 @@ class ProcessorInstructionDurations(InstructionDurations):
             TranspilerError: No duration is defined for the instruction.
         """
         if isinstance(inst, Barrier):
+            return 0
+        elif isinstance(inst, ControlFlowOp):
             return 0
         elif isinstance(inst, Delay):
             with warnings.catch_warnings():

--- a/qiskit_alice_bob_provider/local/target.py
+++ b/qiskit_alice_bob_provider/local/target.py
@@ -16,7 +16,13 @@
 
 from typing import Dict, List, Tuple
 
-from qiskit.circuit import Instruction
+from qiskit.circuit import (
+    ForLoopOp,
+    IfElseOp,
+    Instruction,
+    SwitchCaseOp,
+    WhileLoopOp,
+)
 from qiskit.transpiler import Target
 
 from ..processor.description import ProcessorDescription
@@ -99,6 +105,14 @@ def processor_to_target(processor: ProcessorDescription) -> Target:
             properties=properties,
             name=qiskit_instr.name,
         )
+    # Add essential control flow operations to the target
+    # framework because it doesn't include control
+    # flow operations by default.
+    target.add_instruction(IfElseOp, name='if_else')
+    target.add_instruction(WhileLoopOp, name='while_loop')
+    target.add_instruction(ForLoopOp, name='for_loop')
+    target.add_instruction(SwitchCaseOp, name='switch_case')
+
     target._instruction_durations = (  # pylint: disable=protected-access
         ProcessorInstructionDurations(processor=processor)
     )

--- a/qiskit_alice_bob_provider/plugins/ab_asap.py
+++ b/qiskit_alice_bob_provider/plugins/ab_asap.py
@@ -16,9 +16,10 @@
 
 from typing import cast
 
+from qiskit.circuit import ControlFlowOp
 from qiskit.transpiler import PassManager, PassManagerConfig
 from qiskit.transpiler.instruction_durations import InstructionDurations
-from qiskit.transpiler.passes import TimeUnitConversion
+from qiskit.transpiler.passes import ASAPScheduleAnalysis, TimeUnitConversion
 from qiskit.transpiler.preset_passmanagers.common import generate_scheduling
 from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
 
@@ -100,6 +101,16 @@ class AliceBobASAPSchedulingPlugin(PassManagerStagePlugin):
                         CustomTimeUnitConversion(
                             target=pass_manager_config.target
                         ),
+                    )
+                if isinstance(subtask, ASAPScheduleAnalysis):
+                    # By default, the ASAPScheduleAnalysis pass only supports
+                    # conditionals for Gate & Delay instructions. We add the
+                    # support for ControlFlowOp (which itself allows for
+                    # If-Else, For-Loop, While-Loop and Switch-Case
+                    # to be supported)
+                    subtask.CONDITIONAL_SUPPORTED = (
+                        *subtask.CONDITIONAL_SUPPORTED,
+                        ControlFlowOp,
                     )
 
         return pm

--- a/qiskit_alice_bob_provider/plugins/sk_synthesis.py
+++ b/qiskit_alice_bob_provider/plugins/sk_synthesis.py
@@ -70,15 +70,14 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
         discrete_basis_gates: Set[str] = set()
         discrete_1q_basis_gates: Set[str] = set()
         for instr, _ in target.instructions:
-            if isclass(instr):
-                # At this point, the control flow operations
-                # are not yet instantiated which means the
-                # instruction can be a class. We have to check if
-                # the class is a subclass of 'ControlFlowOp',
-                # in which case we can skip the rest of the loop
-                # iteration to avoid throwing any errors.
-                if issubclass(instr, ControlFlowOp):
-                    continue
+            # At this point, the control flow operations
+            # are not yet instantiated which means the
+            # instruction can be a class. We have to check if
+            # the class is a subclass of 'ControlFlowOp',
+            # in which case we can skip the rest of the loop
+            # iteration to avoid throwing any errors.
+            if isclass(instr) and issubclass(instr, ControlFlowOp):
+                continue
 
             assert isinstance(instr, Instruction)
             if len(instr.params) != 0 or instr.name in {

--- a/tests/local/test_control_flow_operators.py
+++ b/tests/local/test_control_flow_operators.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pytest
+from qiskit import (
+    ClassicalRegister,
+    QuantumCircuit,
+    QuantumRegister,
+    transpile,
+)
+
+from qiskit_alice_bob_provider import AliceBobLocalProvider
+
+qreg = QuantumRegister(1, 'q')
+creg = ClassicalRegister(1, 'c')
+
+
+def get_backends():
+    """
+    Return a list of all the names of each available backends.
+    This is for better logging when running the tests.
+    """
+    provider = AliceBobLocalProvider()
+    return [backend.name for backend in provider.backends()]
+
+
+def generate_basic_circuit():
+    basic_circ = QuantumCircuit(qreg, creg)
+    basic_circ.name = 'Basic'
+    basic_circ.rz(np.pi, qreg[0])  # Equivalent to X gate
+    basic_circ.measure(qreg[0], creg[0])
+    return basic_circ
+
+
+def generate_if_circuit():
+    if_else_circ = QuantumCircuit(qreg, creg)
+    if_else_circ.name = 'If_Else'
+    if_else_circ.rz(np.pi, qreg[0])  # Equivalent to X gate
+    if_else_circ.measure(qreg[0], creg[0])
+
+    with if_else_circ.if_test((creg[0], 1)) as _else:
+        if_else_circ.rz(np.pi, qreg[0])  # Apply RZ(pi) if measured 1
+    with _else:
+        if_else_circ.rz(np.pi, qreg[0])  # Apply RZ(pi) if measured 0
+    if_else_circ.measure(qreg[0], creg[0])
+    return if_else_circ
+
+
+def generate_while_circuit():
+    while_circ = QuantumCircuit(qreg, creg)
+    while_circ.name = 'While'
+    while_circ.rz(np.pi, qreg[0])  # Ensure q[0] is initially |1>
+    while_circ.measure(qreg[0], creg[0])
+
+    with while_circ.while_loop((creg[0], 1)):
+        while_circ.rz(np.pi, qreg[0])
+        while_circ.measure(qreg[0], creg[0])
+    return while_circ
+
+
+def generate_for_circuit():
+    for_circ = QuantumCircuit(qreg, creg)
+    for_circ.name = 'For'
+    with for_circ.for_loop(range(3)):
+        for_circ.rz(np.pi, qreg[0])
+    for_circ.measure(qreg[0], creg[0])
+    return for_circ
+
+
+def generate_switch_circuit():
+    switch_circ = QuantumCircuit(qreg, creg)
+    switch_circ.name = 'Switch'
+    switch_circ.measure(qreg[0], creg[0])
+
+    with switch_circ.switch(creg[0]) as case:
+        with case(0):
+            switch_circ.rz(np.pi, qreg[0])  # Apply RZ(pi) if measured 0
+        with case(1):
+            switch_circ.rz(np.pi, qreg[0])  # Apply RZ(pi) if measured 1
+    switch_circ.measure(qreg[0], creg[0])
+    return switch_circ
+
+
+CIRCUITS = [
+    generate_basic_circuit,
+    generate_if_circuit,
+    generate_while_circuit,
+    generate_for_circuit,
+    generate_switch_circuit,
+]
+
+
+@pytest.mark.parametrize('make_circ', CIRCUITS)
+@pytest.mark.parametrize('backend_name', get_backends())
+def test_circuit_runs_on_simulators(make_circ, backend_name):
+    provider = AliceBobLocalProvider()
+    backend = provider.get_backend(backend_name)
+    circuit = make_circ()
+    transpiled = transpile(circuit, backend)
+    job = backend.run(transpiled, shots=10)
+    result = job.result()
+    assert result.success is True
+
+    if circuit.name == 'If_Else':
+        assert any(instr for instr in circuit.data if instr.name == 'if_else')
+    elif circuit.name == 'While':
+        assert any(
+            instr for instr in circuit.data if instr.name == 'while_loop'
+        )
+    elif circuit.name == 'For':
+        assert any(instr for instr in circuit.data if instr.name == 'for_loop')
+    elif circuit.name == 'Switch':
+        assert any(
+            instr for instr in circuit.data if instr.name == 'switch_case'
+        )

--- a/tests/remote/test_backend.py
+++ b/tests/remote/test_backend.py
@@ -225,7 +225,6 @@ def test_translation_plugin_and_qir(mocked_targets) -> None:
     c = QuantumCircuit(4, 4)
     c.initialize('-01+')
     c.measure([0, 1], [2, 3])
-    c.x(2).c_if(2, 1)
     c.measure_x(2, 0)
     c.measure_x(3, 1)
 

--- a/tests/resources/test_translation_plugin_and_qir.ll
+++ b/tests/resources/test_translation_plugin_and_qir.ll
@@ -4,20 +4,9 @@ entry:
   call void @__quantum__qis__prepare_z__body(i1 true, %Qubit* inttoptr (i64 1 to %Qubit*))
   call void @__quantum__qis__prepare_z__body(i1 false, %Qubit* inttoptr (i64 2 to %Qubit*))
   call void @__quantum__qis__prepare_x__body(i1 true, %Qubit* inttoptr (i64 3 to %Qubit*))
+  call void @__quantum__qis__mx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* null)
   call void @__quantum__qis__mx__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
   call void @__quantum__qis__mz__body(%Qubit* null, %Result* inttoptr (i64 2 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
-  br i1 %0, label %then, label %else
-
-then:                                             ; preds = %entry
-  call void @__quantum__qis__x__body(%Qubit* inttoptr (i64 2 to %Qubit*))
-  br label %continue
-
-else:                                             ; preds = %entry
-  br label %continue
-
-continue:                                         ; preds = %else, %then
-  call void @__quantum__qis__mx__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* null)
   call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
   call void @__quantum__rt__array_record_output(i64 4, i8* null)
   call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)


### PR DESCRIPTION
This PR adds support for all control flow operations across our backends. Each of our processors uses the AerSimulator backend, which already supported these operations. Since these operators behave differently from instructions, we don't yield them from the all_instructions function in the ProcessorDescriptor. Instead, we directly add them to our target for processing.