### PR TITLE
Feat/add parsing of sdg gates from qir to qiskit

### DIFF
--- a/qiskit_alice_bob_provider/remote/qir_to_qiskit.py
+++ b/qiskit_alice_bob_provider/remote/qir_to_qiskit.py
@@ -32,6 +32,7 @@ from qiskit.circuit.library import (
     RYGate,
     RZGate,
     RZZGate,
+    SdgGate,
     SGate,
     SwapGate,
     TdgGate,
@@ -125,6 +126,8 @@ def _qir_signature_to_qiskit_instructions(
         return [('rz', RZGate(phi))]
     elif instr_short_name == 's':
         return [('s', SGate())]
+    elif instr_short_name == 'sdg':
+        return [('sdg', SdgGate())]
     elif instr_short_name == 'swap':
         return [('swap', SwapGate())]
     elif instr_short_name == 't':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,7 @@ def all_instructions_target() -> dict:
             {'signature': '__quantum__qis__y__body:void (%Qubit*)'},
             {'signature': '__quantum__qis__h__body:void (%Qubit*)'},
             {'signature': '__quantum__qis__s__body:void (%Qubit*)'},
+            {'signature': '__quantum__qis__s__adj:void (%Qubit*)'},
             {'signature': '__quantum__qis__t__body:void (%Qubit*)'},
             {
                 'signature': (


### PR DESCRIPTION
Linked to [this issue](https://git.alice-bob.com/alice-bob/cloud/generic-tasks/-/issues/740)

Translation from qir to qiskit was missing the translation for the sdg gate, which was supported by our local Logical processor while not being available for the remote backends. 
