### PR TITLE
fix: typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,7 +261,7 @@ This commit does this by removing CZ & CCZ from the list of gates to synthesize,
   ([`9f1656c`](https://github.com/Alice-Bob-SW/qiskit-alice-bob-provider/commit/9f1656ce7f2700513bdc99480295bbfdd27600cc))
 
 We are missing this step to be able to transpile circuits with custom defined gates (such as
-  Margolus). The gates are now unrolled to their lowest definitions before being synthetized.
+  Margolus). The gates are now unrolled to their lowest definitions before being synthesized.
 
 ### Documentation
 

--- a/qiskit_alice_bob_provider/local/patch/local_noise_pass.py
+++ b/qiskit_alice_bob_provider/local/patch/local_noise_pass.py
@@ -140,7 +140,7 @@ class LocalNoisePass(TransformationPass):
                 )
 
             # If the new op is not a QuantumCircuit or Instruction, attempt
-            # to conver to an Instruction
+            # to convert to an Instruction
             if not isinstance(new_op, (QuantumCircuit, Instruction)):
                 try:
                     new_op = new_op.to_instruction()

--- a/qiskit_alice_bob_provider/local/quantum_errors.py
+++ b/qiskit_alice_bob_provider/local/quantum_errors.py
@@ -41,7 +41,7 @@ def build_quantum_error_passes(
     quantum processor.
 
     Note that the readout errors are not inserted by these transpilation
-    passes. Readout errors are handled separately and are contined in the
+    passes. Readout errors are handled separately and are contained in the
     simulation NoiseModel.
     """
 
@@ -241,7 +241,7 @@ def _pass_factory(
         # simulation performance because the wrapping sub-circuit is transpiled
         # away later right before simulation.
         # Can't we just rename the error instruction itself? No because it
-        # needs to have the name "kraus" for Qiskit Aer to understand what thi
+        # needs to have the name "kraus" for Qiskit Aer to understand what this
         # is.
         wrapper_circ = QuantumCircuit(
             error_instr.num_qubits,

--- a/qiskit_alice_bob_provider/plugins/ab_asap.py
+++ b/qiskit_alice_bob_provider/plugins/ab_asap.py
@@ -93,7 +93,7 @@ class AliceBobASAPSchedulingPlugin(PassManagerStagePlugin):
         # pylint: disable=protected-access
         for task in pm._tasks:
             for i, subtask in enumerate(task):
-                # Substitue the default TimeUnitConversion with our
+                # Substitute the default TimeUnitConversion with our
                 # custom implementation.
                 if isinstance(subtask, TimeUnitConversion):
                     pm.replace(

--- a/qiskit_alice_bob_provider/plugins/sk_synthesis.py
+++ b/qiskit_alice_bob_provider/plugins/sk_synthesis.py
@@ -157,7 +157,7 @@ class SKSynthesisPlugin(PassManagerStagePlugin):
                         # pylint: disable=protected-access
                         subtask._synth_gates = synth_gates
                         # Can't pass basis gates in
-                        # unitary_synthesis_plugin_config because overriden
+                        # unitary_synthesis_plugin_config because overridden
                         # by global basis_gates.
                         # This seems to be a Qiskit bug (why give the
                         # possibility to specify basis gates in the plugin

--- a/qiskit_alice_bob_provider/plugins/state_preparation.py
+++ b/qiskit_alice_bob_provider/plugins/state_preparation.py
@@ -133,8 +133,8 @@ class EnsurePreparationPass(TransformationPass):
 
 class IntToLabelInitializePass(TransformationPass):
     """
-    A transpilation pass that transforms intializations using integers into
-    intializations using labels.
+    A transpilation pass that transforms initializations using integers into
+    initializations using labels.
 
     Example:
     ```

--- a/qiskit_alice_bob_provider/processor/description.py
+++ b/qiskit_alice_bob_provider/processor/description.py
@@ -103,7 +103,7 @@ class ProcessorDescription(ABC):
     # in the ProcessorDescription (usually seconds).
     #
     # Note that the ProcessorDescription does not return durations in
-    # multiples of the clock cyle and accepts durations (e.g., for delay)
+    # multiples of the clock cycle and accepts durations (e.g., for delay)
     # that are not multiples of clock cycle.
     #
     # If respecting the clock cycle is important, it is up to the user (e.g.,

--- a/tests/local/test_backend.py
+++ b/tests/local/test_backend.py
@@ -86,13 +86,13 @@ def test_translation_plugin() -> None:
     transpiled = transpile(circ, backend)
     _assert_one_initialize(transpiled, '0')
 
-    # if reset, convert to Intialize('0')
+    # if reset, convert to Initialize('0')
     circ = QuantumCircuit(1)
     circ.reset(0)
     transpiled = transpile(circ, backend)
     _assert_one_initialize(transpiled, '0')
 
-    # if reset, convert to Intialize('0')
+    # if reset, convert to Initialize('0')
     circ = QuantumCircuit(3)
     circ.initialize(2, [0, 1])
     circ.reset(2)

--- a/tests/remote/test_backend.py
+++ b/tests/remote/test_backend.py
@@ -88,7 +88,7 @@ def test_get_backend_options_validation(mocked_targets) -> None:
 
 
 def test_execute_options_validation(mocked_targets) -> None:
-    # We are permissive in our options sytem, allowing the user to both
+    # We are permissive in our options system, allowing the user to both
     # define options when creating the backend and executing.
     # We therefore need to test both behaviors.
     c = QuantumCircuit(1, 1)


### PR DESCRIPTION
## Summary
**Fix typos**
- synthetized -> synthesized
- conver -> convert
- contined -> contained
- thi -> this
- Substitue -> Substitute
- overriden -> overridden
- intializations -> initializations
- cyle -> cycle
- Intialize -> Initialize
- sytem -> system